### PR TITLE
Add usage page

### DIFF
--- a/index.html
+++ b/index.html
@@ -581,6 +581,7 @@
                     <ul class="text-sm text-gray-400 space-y-1">
                         <li><a href="#" onclick="showPrivacyPolicy()">プライバシーポリシー</a></li>
                         <li><a href="#" onclick="showTerms()">利用規約</a></li>
+                        <li><a href="#" onclick="showUsage()">使い方</a></li>
                         <li><a href="#" onclick="showContact()">お問い合わせ</a></li>
                     </ul>
                 </div>
@@ -1255,6 +1256,10 @@ https://appadaycreator.github.io/sc-seclab
 
         function showTerms() {
             alert('利用規約（実装予定）');
+        }
+
+        function showUsage() {
+            window.open('./usage.html', '_blank');
         }
 
         function showContact() {

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,5 +5,11 @@
     <lastmod>2024-12-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+</url>
+  <url>
+    <loc>https://appadaycreator.github.io/sc-seclab/usage.html</loc>
+    <lastmod>2024-12-14</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
 </urlset>

--- a/sw.js
+++ b/sw.js
@@ -2,6 +2,7 @@ const CACHE_NAME = 'sc-seclab-v1';
 const urlsToCache = [
   '/sc-seclab/',
   '/sc-seclab/index.html',
+  '/sc-seclab/usage.html',
   '/sc-seclab/manifest.json',
   '/sc-seclab/images/ogp-image.jpg'
 ];

--- a/usage.html
+++ b/usage.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>使い方 - SC-SecLab</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-900 text-gray-200 p-6">
+    <header class="mb-8">
+        <h1 class="text-3xl font-bold">SC-SecLab 使い方</h1>
+    </header>
+
+    <main class="space-y-6">
+        <section>
+            <h2 class="text-2xl font-semibold mb-2">1. 学習プランの生成</h2>
+            <p>トップページの「学習プラン」タブで試験日・現在のレベル・1日の学習時間を入力し、プラン生成ボタンを押すと最適な学習スケジュールが自動作成されます。</p>
+        </section>
+        <section>
+            <h2 class="text-2xl font-semibold mb-2">2. 今日の学習予定を確認</h2>
+            <p>ダッシュボードでは本日の学習タスクが一覧表示されます。計画に沿って学習を進めましょう。</p>
+        </section>
+        <section>
+            <h2 class="text-2xl font-semibold mb-2">3. 過去問演習</h2>
+            <p>「過去問演習」タブから練習問題に挑戦できます。回答後は正解を確認して理解度を高めます。</p>
+        </section>
+        <section>
+            <h2 class="text-2xl font-semibold mb-2">4. 弱点分析と合格予測</h2>
+            <p>学習履歴に基づき弱点を可視化し、現在の合格可能性を確認できます。弱点を重点的に復習しましょう。</p>
+        </section>
+    </main>
+
+    <footer class="mt-10 text-sm text-center text-gray-400">
+        <a href="index.html" class="text-blue-400 hover:underline">トップへ戻る</a>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `usage.html` with Japanese instructions
- link to the usage page from the footer
- open the page via `showUsage()` function
- cache the usage page offline via service worker
- list the new page in `sitemap.xml`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684cf5b2a0f0832e8295ef47452da3f2